### PR TITLE
Add filtering to data views (Fixes #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target/
+/out/
+/resources/test/
+/resources/re-frisk/js/
+/figwheel_server.log

--- a/dev/re_frisk_shell/demo.cljs
+++ b/dev/re_frisk_shell/demo.cljs
@@ -69,10 +69,17 @@
   (start-router!)
   (mount))
 
+(def test-state {:map {:kw "keyword"}
+                 :map-string {"str" "string"}
+                 :set #{1 2 3 {:inset 'inset}}
+                 :array [0 1 2 [0 1 2 {:inarray 'inarray}]]
+                 :map-complicated {[0 1 2 #{:foo}] 42}
+                 :kinda-number {"0x0abc" -1}})
+
 ;ENTRY POINT TEST
 (defn ^:export runtest [port]
   (mount)
-  (update-app-db {:test "TEST"})
+  (update-app-db {:test test-state})
   (update-events [:test-event {:test "TEST"}]))
 
 (defn on-js-reload []

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,13 @@
             :url "https://opensource.org/licenses/MIT"}
 
   :dependencies [[reagent "0.7.0"]
-                 [re-com "2.1.0"]]
+                 [re-com "2.1.0"]
+                 [org.clojure/clojure "1.9.0-RC1"]
+                 [org.clojure/clojurescript "1.9.946"]]
 
   :plugins [[lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]
-            [lein-figwheel "0.5.13"]]
+            [lein-figwheel "0.5.13"]
+            [lein-doo "0.1.8"]]
 
   :source-paths ["src"]
 
@@ -26,10 +29,21 @@
                            :asset-path "js/compiled/out/re-frisk"
                            :output-to "resources/re-frisk/js/compiled/re_frisk.js"
                            :output-dir "resources/re-frisk/js/compiled/out/re-frisk"
-                           :source-map-timestamp true}}]}
+                           :source-map-timestamp true}}
+               {:id "test"
+                :source-paths ["src" "dev" "test"]
+                :compiler {:main re-frisk-shell.test-runner
+                           :output-to "resources/test/test.js"
+                           :optimizations :none
+                           :target :nodejs}}]}
+
+  :doo {:build "test"
+        :alias {:default [:node]}}
 
   :profiles {:dev {:dependencies [[binaryage/devtools "0.7.2"]
-                                  [com.taoensso/sente "1.11.0"]
+                                  ;; https://github.com/ptaoussanis/sente/issues/311
+                                  [com.taoensso/sente "1.11.0" :exclusions [org.clojure/core.async]]
+                                  [org.clojure/core.async "0.3.443"]
                                   [com.cognitect/transit-cljs "0.8.239"]
                                   [figwheel-sidecar "0.5.4-7"]
                                   [com.cemerick/piggieback "0.2.1"]]}})

--- a/src/re_frisk_shell/filter_matcher.cljs
+++ b/src/re_frisk_shell/filter_matcher.cljs
@@ -1,0 +1,25 @@
+(ns re-frisk-shell.filter-matcher
+  (:require [clojure.string :as str]))
+
+(defn- match-expr [f p]
+  (= f p))
+
+(defn- match-string-prefix [f p]
+  (and (string? p) (str/starts-with? p f)))
+
+(defn- match-free [f p]
+  (str/includes? (str p) f))
+
+(defn- match-value [f p]
+  (cond (contains? f :expr) (match-expr (:expr f) p)
+        (contains? f :string-prefix) (match-string-prefix (:string-prefix f) p)
+        (contains? f :free) (match-free (:free f) p)
+        :else (throw (js/Error. (str "Unknown kind of filter-path: " f)))))
+
+(defn match [filter path]
+  (cond (empty? filter) nil
+        (empty? path) nil
+        (= (count filter) 1) (match-value (first filter) (last path))
+        :else (if (match-value (first filter) (first path))
+                (recur (rest filter) (rest path))
+                (recur filter (rest path)))))

--- a/src/re_frisk_shell/filter_parser.cljs
+++ b/src/re_frisk_shell/filter_parser.cljs
@@ -1,0 +1,58 @@
+(ns re-frisk-shell.filter-parser
+  (:require [cljs.tools.reader.reader-types
+             :refer [string-push-back-reader peek-char read-char]]
+            [cljs.tools.reader :as reader]
+            [clojure.string :as str]))
+
+(defn- read-all [rdr]
+  (case (peek-char rdr)
+    nil '()
+    (cons (read-char rdr) (read-all rdr))))
+
+;; like reader/read-string, but returns unread portion of the string too
+(defn- read-string' [s]
+  (let [sr (string-push-back-reader s)
+        val (reader/read sr)
+        rest (str/join (read-all sr))]
+    {:val val :rest rest}))
+
+(defn- parse-freeform [s]
+  (let [[prefix rest] (str/split s #"\s+" 2)]
+    {:val {:free prefix} :rest (or rest "")}))
+
+(defn- parse-clojure-expr [s]
+  (try
+    (let [{:keys [val rest] :as foo} (read-string' s)]
+      {:val {:expr val} :rest rest})
+    (catch :default _ (parse-freeform s))))
+
+(defn- parse-clojure-string [s]
+  (try
+    (let [{val :val rest :rest} (read-string' s)]
+      {:val {:expr val} :rest rest})
+    (catch :default _
+      ;; If a string cannot be fully parsed, mark it as "unfinished"
+      ;; to do the prefix match later: "abc will match "abc" and "abcde"
+      (let [[prefix rest] (str/split s #"\s+" 2)
+            prefix (str/replace prefix #"^\"" "")] ; Kill " at the beginning
+        {:val {:string-prefix prefix} :rest (or rest "")}))))
+
+(defn- parse-part [s]
+  (case (first s)
+    ;; If it looks like a Clojure literal, parse it as such
+    ("[" "(" "{" "#" "\\" "'" ":") (parse-clojure-expr s)
+    ;; If it looks like a string, parse it as a string (relaxed)
+    "\"" (parse-clojure-string s)
+    ;; Otherwise it's a freeform
+    (parse-freeform s)))
+
+(defn- parse' [s]
+  (let [s (str/trim s)
+        ;; Remove outer [] of the expression, if any
+        s (str/replace s #"^\[(.*)\]$" "$1")]
+    (if (= s "") '()
+        (let [{val :val rest :rest} (parse-part s)]
+          (cons val (parse' rest))))))
+
+(defn parse [s]
+  (into [] (parse' s)))

--- a/src/re_frisk_shell/frisk.cljs
+++ b/src/re_frisk_shell/frisk.cljs
@@ -359,7 +359,6 @@
                  :expanded-paths (get-in data-frisk [id :expanded-paths])
                  :matching-paths matching
                  :expanded-matching-paths expanded-matching
-                 :filter (or (get-in data-frisk [id :filter]) [])
                  :emit-fn emit-fn}]]))
 
 (def expand-by-default (reduce #(assoc-in %1 [:data-frisk %2 :expanded-paths] #{[]}) {} (range 1)))

--- a/src/re_frisk_shell/frisk.cljs
+++ b/src/re_frisk_shell/frisk.cljs
@@ -62,8 +62,9 @@
 
 (defn node-clicked [{:keys [event emit-fn path] :as all}]
   (.stopPropagation event)
-  (when (.-shiftKey event)
-    (emit-fn :copy path)))
+  (if (.-shiftKey event)
+    (emit-fn :copy path)
+    (emit-fn :filter-change (str path))))
 
 (defn NilText []
   [:span {:style (:nil styles)} (pr-str nil)])

--- a/src/re_frisk_shell/frisk.cljs
+++ b/src/re_frisk_shell/frisk.cljs
@@ -352,7 +352,7 @@
 (defn prefixes [path]
   (set (reductions conj [] path)))
 
-;; Any node which is a prefix of a matched path need to be expnaded
+;; Any node which is a prefix of a matched path needs to be expnaded
 (defn expanded-matching-paths [paths]
   (apply set/union (map prefixes paths)))
 

--- a/src/re_frisk_shell/frisk.cljs
+++ b/src/re_frisk_shell/frisk.cljs
@@ -16,7 +16,7 @@
 (defn ExpandButton [{:keys [expanded? path emit-fn]}]
   [:button {:style {:border 0
                     :backgroundColor "transparent" :width "20px" :height "20px"}
-            :onClick #(emit-fn (if expanded? :contract :expand) path)}
+            :on-click #(emit-fn (if expanded? :contract :expand) path)}
    [:svg {:viewBox "0 0 100 100"
           :width "100%" :height "100%"
           :style {:transition "all 0.2s ease"
@@ -35,7 +35,7 @@
    :shell-visible-button {:backgroundColor "#4EE24E"}})
 
 (defn ExpandAllButton [emit-fn data]
-  [:button {:onClick #(emit-fn :expand-all data)
+  [:button {:on-click #(emit-fn :expand-all data)
             :style {:padding "0px"
                     :borderTopLeftRadius "2px"
                     :borderBottomLeftRadius "2px"
@@ -45,7 +45,7 @@
    "Expand all"])
 
 (defn CollapseAllButton [emit-fn data]
-  [:button {:onClick #(emit-fn :collapse-all)
+  [:button {:on-click #(emit-fn :collapse-all)
             :style {:padding "0px"
                     :cursor "pointer"
                     :borderTopRightRadius "2px"
@@ -69,7 +69,7 @@
 
 (defn FilterReset [emit-fn]
   [:button {:style {:margin-right 5 :width 25}
-            :onClick #(emit-fn :filter-change "" 0)} "X"])
+            :on-click #(emit-fn :filter-change "" 0)} "X"])
 
 (defn node-clicked [{:keys [event emit-fn path] :as all}]
   (.stopPropagation event)
@@ -97,7 +97,7 @@
      [:span {:style {:padding-left "20px"}}
       [Node node]])
    [:span
-    {:onClick #(node-clicked {:event % :emit-fn emit-fn :path path})
+    {:on-click #(node-clicked {:event % :emit-fn emit-fn :path path})
      :style (merge (when node {:padding-left "10px"})
                    (when (get matching-paths path)
                      {:background-color "#fff9db"}))}

--- a/src/re_frisk_shell/frisk.cljs
+++ b/src/re_frisk_shell/frisk.cljs
@@ -73,9 +73,7 @@
 
 (defn node-clicked [{:keys [event emit-fn path] :as all}]
   (.stopPropagation event)
-  (if (.-shiftKey event)
-    (emit-fn :copy path)
-    (emit-fn :filter-change (str path) 0)))
+  (emit-fn :filter-change (str path) 0))
 
 (defn NilText []
   [:span {:style (:nil styles)} (pr-str nil)])
@@ -266,31 +264,6 @@
                   expanded-paths))))
       expanded-paths)))
 
-; Taken from prbroadfoot/data-frisk-reagent, MIT-licensed
-(defn copy-to-clipboard [data]
-  (let [textArea (.createElement js/document "textarea")]
-    (doto textArea
-      ;; Put in top left corner of screen
-      (aset "style" "position" "fixed")
-      (aset "style" "top" 0)
-      (aset "style" "left" 0)
-      ;; Make it small
-      (aset "style" "width" "2em")
-      (aset "style" "height" "2em")
-      (aset "style" "padding" 0)
-      (aset "style" "border" "none")
-      (aset "style" "outline" "none")
-      (aset "style" "boxShadow" "none")
-      ;; Avoid flash of white box
-      (aset "style" "background" "transparent")
-      (aset "value" data))
-
-    (.appendChild (.-body js/document) textArea)
-    (.select textArea)
-
-    (.execCommand js/document "copy")
-    (.removeChild (.-body js/document) textArea)))
-
 (defn parenthesize [s]
   (str "[" (-> s
                (str/replace #"^[\[]" "")
@@ -313,7 +286,6 @@
       :expand-all (swap! state-atom assoc-in [:data-frisk id :expanded-paths] (expand-all-paths (first args)))
       :contract (swap! state-atom update-in [:data-frisk id :expanded-paths] disj (first args))
       :collapse-all (swap! state-atom assoc-in [:data-frisk id :expanded-paths] #{})
-      :copy (copy-to-clipboard (first args))
       :filter-change
       (do
         (swap! state-atom assoc-in [:data-frisk id :raw-filter] (first args))

--- a/src/re_frisk_shell/frisk.cljs
+++ b/src/re_frisk_shell/frisk.cljs
@@ -54,7 +54,7 @@
   [:input {:type "text"
              :style {:flex 1 :margin-left 5}
              :value filter
-             :placeholder "[:a :b ...]"
+             :placeholder "Type here to find keys..."
              :on-change #(emit-fn :filter-change (.. % -target -value))}])
 
 (defn FilterReset [emit-fn]

--- a/src/re_frisk_shell/frisk.cljs
+++ b/src/re_frisk_shell/frisk.cljs
@@ -99,7 +99,7 @@
      [:span {:style {:padding-left "20px"}}
       [Node node]])
    [:span
-    {:onClick #(node-clicked {:event %, :emit-fn emit-fn :path path})
+    {:onClick #(node-clicked {:event % :emit-fn emit-fn :path path})
      :style (merge (when node {:padding-left "10px"})
                    (when (get matching-paths path)
                      {:background-color "#fff9db"}))}

--- a/src/re_frisk_shell/frisk.cljs
+++ b/src/re_frisk_shell/frisk.cljs
@@ -57,7 +57,7 @@
                     :backgroundColor "white"}}
    "Collapse all"])
 
-(def edit-debounce-ms 150)
+(def edit-debounce-ms 400)
 
 (defn FilterEditBox [emit-fn filter]
   [:input {:type "text"

--- a/test/re_frisk_shell/filter_matcher_test.cljs
+++ b/test/re_frisk_shell/filter_matcher_test.cljs
@@ -1,0 +1,82 @@
+(ns re-frisk-shell.filter-matcher-test
+  (:require [cljs.test :refer [deftest is]]
+            [re-frisk-shell.filter-matcher :as sut]))
+
+(deftest test-paths
+  ;; Exact matches match
+  (is (sut/match [{:expr :a} {:expr :b} {:expr :c}] [:a :b :c]))
+  ;; Internal nodes and prefixes are skipped
+  (is (sut/match [{:expr :a} {:expr :b} {:expr :c}] ["" :a :b :c]))
+  (is (sut/match [{:expr :a} {:expr :b} {:expr :c}] ["" "" :a :b :c]))
+  (is (sut/match [{:expr :a} {:expr :b} {:expr :c}] [:a "" :b "" :c]))
+  ;; The last entry always has to match
+  (is (not (sut/match [{:expr :a} {:expr :b} {:expr :c}] [:a :b :c ""]))))
+
+(deftest test-expr
+  ;; symbol matches itself
+  (is (sut/match [{:expr 'foo}] ['foo]))
+  ;; But nothing else
+  (is (not (sut/match [{:expr 'foo}] ["foo"])))
+  (is (not (sut/match [{:expr 'foo}] [:foo])))
+  ;; keyword matches itself
+  (is (sut/match [{:expr :foo}] [:foo]))
+  ;; But nothing else
+  (is (not (sut/match [{:expr :foo}] ["foo"])))
+  (is (not (sut/match [{:expr :foo}] ['foo])))
+  ;; character matches itself and string
+  (is (sut/match [{:expr \n}] [\n]))
+  (is (sut/match [{:expr \n}] ["n"]))
+  ;; But nothing else
+  (is (not (sut/match [{:expr \n}] ["nnn"])))
+  (is (not (sut/match [{:expr \n}] ['n])))
+  ;; string matches itself
+  (is (sut/match [{:expr "foo"}] ["foo"]))
+  ;; But nothing else
+  (is (not (sut/match [{:expr "foo"}] ["foobar"])))
+  (is (not (sut/match [{:expr "foo"}] [:foo])))
+  (is (not (sut/match [{:expr "foo"}] ['foo])))
+  ;; string matches itself
+  (is (sut/match [{:expr "foo"}] ["foo"]))
+  ;; But nothing else
+  (is (not (sut/match [{:expr "foo"}] ["foobar"])))
+  (is (not (sut/match [{:expr "foo"}] [:foo])))
+  (is (not (sut/match [{:expr "foo"}] ['foo])))
+  ;; set matches itself
+  (is (sut/match [{:expr #{1}}] [#{1}]))
+  ;; But nothing else
+  (is (not (sut/match [{:expr #{1}}] [[1]])))
+  (is (not (sut/match [{:expr #{1}}] ["1"])))
+  ;; map matches itself
+  (is (sut/match [{:expr {:a :b}}] [{:a :b}]))
+  ;; but nothing else
+  (is (not (sut/match [{:expr {:a :b}}] [[:a :b]])))
+  (is (not (sut/match [{:expr {:a :b}}] [#{:a}])))
+  (is (not (sut/match [{:expr {:a :b}}] ["{:a :b}"]))))
+
+(deftest test-string-prefix
+  ;; string prefix matches string prefixes
+  (is (sut/match [{:string-prefix "abc"}] ["abc"]))
+  (is (sut/match [{:string-prefix "abc"}] ["abcdef"]))
+  ;; but not substrings
+  (is (not (sut/match [{:string-prefix "abc"}] ["defabc"])))
+  (is (not (sut/match [{:string-prefix "abc"}] ["defabcdef"])))
+  ;; and not other types
+  (is (not (sut/match [{:string-prefix "abc"}] [:abc])))
+  (is (not (sut/match [{:string-prefix "abc"}] ['abc])))
+  (is (not (sut/match [{:string-prefix "abc"}] [{:abc :abc}]))))
+
+(deftest test-free
+  ;; freeform match matches any substring
+  (is (sut/match [{:free "a"}] ["a"]))
+  (is (sut/match [{:free "a"}] ["bab"]))
+  (is (sut/match [{:free "a"}] ['a]))
+  (is (sut/match [{:free "a"}] ['bab]))
+  (is (sut/match [{:free "a"}] [:a]))
+  (is (sut/match [{:free "a"}] [[:a]]))
+  (is (sut/match [{:free "a"}] [{:a 1}]))
+  (is (sut/match [{:free "a"}] [{1 :a}]))
+  (is (sut/match [{:free "a"}] [#{'a}]))
+  (is (not (sut/match [{:free "a"}] ["b"])))
+  (is (not (sut/match [{:free "a"}] [""])))
+  (is (sut/match [{:free "17"}] [17]))
+  )

--- a/test/re_frisk_shell/filter_parser_test.cljs
+++ b/test/re_frisk_shell/filter_parser_test.cljs
@@ -1,5 +1,35 @@
 (ns re-frisk-shell.filter-parser-test
-  (:require [cljs.test :refer [deftest is]]))
+  (:require [cljs.test :refer [deftest is]]
+            [re-frisk-shell.filter-parser :as sut]))
 
-(deftest test-numbers
-  (is (= 1 1)))
+(deftest test-empty
+  (is (= [] (sut/parse "")))
+  (is (= [] (sut/parse "    "))))
+
+(deftest test-clojure-literal
+  (is (= [{:expr '(1 2)} (sut/parse "(1 2)")]))
+  (is (= [{:expr '(1 2)} (sut/parse "   (1 2) ")]))
+  (is (= [{:expr [1 2]}  (sut/parse "   [1 2] ")]))
+  (is (= [{:expr :foo} (sut/parse "   :foo ")]))
+  (is (= [{:expr '(2)} {:free "foobar"}] (sut/parse "( 2) foobar"))))
+
+(deftest test-string
+  (is (= [{:expr "123"}] (sut/parse "\"123\"")))
+  (is (= [{:expr ""}] (sut/parse "\"\""))))
+
+(deftest test-stringish
+  (is (= [{:string-prefix "123"}] (sut/parse "\"123"))))
+
+(deftest test-freeform
+  (is (= [{:free ":"}] (sut/parse ":")))
+  (is (= [{:free "0x0"}] (sut/parse "0x0")))
+  (is (= [{:free "0argh"}] (sut/parse "0argh"))))
+
+(deftest test-many
+  (is (= [{:free ":"} {:expr [1]} {:string-prefix "123"}]
+         (sut/parse ": [1] \"123"))))
+
+(deftest test-full-path
+  ;; If the whole expression is wrapped in [], parse it is a path
+  ;; FIXME: maybe don't output [] for paths instead?
+  (is (= [{:free "1"} {:free "2"} {:free "3"}] (sut/parse "[1 2 3]"))))

--- a/test/re_frisk_shell/filter_parser_test.cljs
+++ b/test/re_frisk_shell/filter_parser_test.cljs
@@ -1,0 +1,5 @@
+(ns re-frisk-shell.filter-parser-test
+  (:require [cljs.test :refer [deftest is]]))
+
+(deftest test-numbers
+  (is (= 1 1)))

--- a/test/re_frisk_shell/test_runner.cljs
+++ b/test/re_frisk_shell/test_runner.cljs
@@ -1,5 +1,7 @@
 (ns re-frisk-shell.test-runner
   (:require [doo.runner :refer-macros [doo-tests]]
-            [re-frisk-shell.filter-parser-test]))
+            [re-frisk-shell.filter-parser-test]
+            [re-frisk-shell.filter-matcher-test]))
 
-(doo-tests 're-frisk-shell.filter-parser-test)
+(doo-tests 're-frisk-shell.filter-parser-test
+           're-frisk-shell.filter-matcher-test)

--- a/test/re_frisk_shell/test_runner.cljs
+++ b/test/re_frisk_shell/test_runner.cljs
@@ -1,0 +1,5 @@
+(ns re-frisk-shell.test-runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [re-frisk-shell.filter-parser-test]))
+
+(doo-tests 're-frisk-shell.filter-parser-test)


### PR DESCRIPTION
- Select filters values (in a relaxed way, akin' to modern IDE filtering)
- Clicking on a node selects it
- Shift-clicking on a node copies its path to the clipboard
